### PR TITLE
Fix: Source filter setting input should be a string

### DIFF
--- a/module.json
+++ b/module.json
@@ -835,7 +835,7 @@
             "request Id": { "type":"String"},
             "sourceName": { "type":"String"},
 			"filterName": { "type":"String"},
-			"filterSettings": { "type":"Integer","min":0},
+			"filterSettings": { "type":"String"},
 			"overlay": { "type":"Boolean", "default":true},
          }
       },


### PR DESCRIPTION
The input of the source filter setting should be a string