### PR TITLE
Fix order of SceneItemEnableStateChanged

### DIFF
--- a/OBS.js
+++ b/OBS.js
@@ -208,9 +208,9 @@ function wsMessageReceived(message) {
 	
 	//SceneItemEnableStateChanged Event
 	if (d.eventType == "SceneItemEnableStateChanged") {
-		valueStringContainerParameter("sceneItemEnabled", "sceneName", d.eventData.sceneName);
 		valueBoolContainerParameter("sceneItemEnabled", "sceneItemEnabled", d.eventData.sceneItemEnabled);
 		valueIntegerContainerParameter("sceneItemEnabled", "sceneItemId", d.eventData.sceneItemId);
+		valueStringContainerParameter("sceneItemEnabled", "sceneName", d.eventData.sceneName);
 	}
 
 	//InputMuteStateChanged


### PR DESCRIPTION
The order was not correct to what OBS sends via events websocket; this caused issues when multiple websocket events happened at once.